### PR TITLE
Preserve Name & Backend Retries

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,11 @@ const defaultMinUpdateInterval = 30
 
 // Default retry limit
 const defaultMaxRetries = 8
+const ProcessordefaultMaxRetries = 8
+const ProcessorDefaultRetryIntvl = 5
+
+// Default Normalizaion of ClusterNames
+const defaultPreserveCase = false
 
 // config file structures
 type tomlConfig struct {
@@ -27,13 +32,16 @@ type tomlConfig struct {
 }
 
 type globalConfig struct {
-	Version         string  `toml:"version"`
-	LogFile         *string `toml:"logfile"`
-	LogToStdout     bool    `toml:"log_to_stdout"`
-	Processor       string  `toml:"stats_processor"`
-	MinUpdateInvtl  int     `toml:"min_update_interval_override"`
-	MaxRetries      int     `toml:"max_retries"`
-	LookupExportIds bool    `toml:"lookup_export_ids"`
+	Version             string  `toml:"version"`
+	LogFile             *string `toml:"logfile"`
+	LogToStdout         bool    `toml:"log_to_stdout"`
+	Processor           string  `toml:"stats_processor"`
+	ProcessorMaxRetries int     `toml:"stats_processor_max_retries"`
+	ProcessorRetryIntvl int     `toml:"stats_processor_retry_interval"`
+	MinUpdateInvtl      int     `toml:"min_update_interval_override"`
+	MaxRetries          int     `toml:"max_retries"`
+	LookupExportIds     bool    `toml:"lookup_export_ids"`
+	PreserveCase        bool    `toml:"preserve_case"` // enable/disable normalization of Cluster Names
 }
 
 type influxDBConfig struct {
@@ -67,12 +75,16 @@ type clusterConf struct {
 	SSLCheck       bool    `toml:"verify-ssl"` // turn on/off SSL cert checking to handle self-signed certificates
 	Disabled       bool    // if set, disable collection for this cluster
 	PrometheusPort *uint64 `toml:"prometheus_port"` // If using the Prometheus collector, define the listener port for the metrics handler
+	PreserveCase   *bool   `toml:"preserve_case"`   // Overwrite normalization of Cluster Name
 }
 
 func mustReadConfig() tomlConfig {
 	var conf tomlConfig
 	conf.Global.MaxRetries = defaultMaxRetries
+	conf.Global.ProcessorMaxRetries = ProcessordefaultMaxRetries
+	conf.Global.ProcessorRetryIntvl = ProcessorDefaultRetryIntvl
 	conf.Global.MinUpdateInvtl = defaultMinUpdateInterval
+	conf.Global.PreserveCase = defaultPreserveCase
 	_, err := toml.DecodeFile(*configFileName, &conf)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: unable to read config file %s, exiting\n", os.Args[0], *configFileName)
@@ -83,7 +95,9 @@ func mustReadConfig() tomlConfig {
 	if conf.Global.MaxRetries <= 0 {
 		conf.Global.MaxRetries = math.MaxInt
 	}
-
+	if conf.Global.ProcessorMaxRetries <= 0 {
+		conf.Global.ProcessorMaxRetries = math.MaxInt
+	}
 	return conf
 }
 

--- a/example_goppstats.toml
+++ b/example_goppstats.toml
@@ -14,6 +14,18 @@ log_to_stdout = false
 # Default configuration uses InfluxDB (v1)
 stats_processor = "influxdb"
 
+# Maximum number of retries in case of errors during write to stat_processor
+# Default is 8 retries. Uncomment the following line to retry forever
+# stats_processor_max_retries = 0
+
+# The stats_processor_retry_interval parameter provides the ability to override the
+# minimum interval that the daemon will retry in case writing to the stats_processor fails.
+# Default is 5 second. Uncomment the following line to start with a 1 second interval.
+# stats_processor_retry_interval = 1
+
+# preserve case of cluster names to lowercase, defaults to false.
+# preserve_case = true
+
 # NFS export id -> export path lookup
 # If set to true, the API user must have readonly ISI_PRIV_NFS privilege
 lookup_export_ids = false
@@ -81,6 +93,7 @@ sd_port = 9999
 # authtype = "basic-auth"
 # disabled = false
 # prometheus_port = 9090
+# preserve_case = true
 #	...
 [[cluster]]
 hostname = "demo.cluster.com"

--- a/isilon_api.go
+++ b/isilon_api.go
@@ -37,17 +37,18 @@ type AuthInfo struct {
 // cluster via the OneFS API
 type Cluster struct {
 	AuthInfo
-	AuthType    string
-	Hostname    string
-	Port        int
-	VerifySSL   bool
-	OSVersion   string
-	ClusterName string
-	baseURL     string
-	client      *http.Client
-	csrfToken   string
-	reauthTime  time.Time
-	maxRetries  int
+	AuthType     string
+	Hostname     string
+	Port         int
+	VerifySSL    bool
+	OSVersion    string
+	ClusterName  string
+	baseURL      string
+	client       *http.Client
+	csrfToken    string
+	reauthTime   time.Time
+	maxRetries   int
+	PreserveCase bool
 }
 
 // DsInfoEntry contains metadata info for a single partitioned performance dataset
@@ -274,7 +275,11 @@ func (c *Cluster) GetClusterConfig() error {
 	release := r["version"]
 	rel := release.(string)
 	c.OSVersion = rel
-	c.ClusterName = strings.ToLower(m["name"].(string))
+	if c.PreserveCase {
+		c.ClusterName = m["name"].(string)
+	} else {
+		c.ClusterName = strings.ToLower(m["name"].(string))
+	}
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version is the released program version
-const Version = "0.23"
+const Version = "0.24"
 const userAgent = "goppstats/" + Version
 
 const PPSampleRate = 30 // Only poll once every 30s


### PR DESCRIPTION
Normalisation of Cluster Names is now configurable via "preserve_case" option.
- Defaults to "false" = normalize to lower case.
- Global setting can be overwritten per individual cluster

Writing Stats to Backend Stats Sink has now configurable Retries:
- "stats_processor_max_retries" defaults to 8
- "stats_processor_retry_interval" defaults to 5 seconds
- "stats_processor_retry_interval" is the initial interval each following interval is the previous interval times 2

All settings are optional and don't break existing configs.