### PR TITLE
Force socket reuseaddr/reuseport on prom endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	go build

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
-	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/sys v0.31.0
 	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/prometheus.go
+++ b/prometheus.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"crypto/subtle"
 	"fmt"
+	"net"
 	"net/http"
 
 	//	"regexp"
@@ -10,7 +12,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -87,6 +92,32 @@ type MetricFamily struct {
 	LabelSet map[string]int
 	// Desc contains the detailed description for this metric
 	Desc string
+}
+
+// Wrapper to set socket reuse options
+func createListener(addr string) (net.Listener, error) {
+	// Create Listener Config
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				// Enable SO_REUSEADDR
+				err := syscall.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+				if err != nil {
+					log.Warningf("Could not set SO_REUSEADDR socket option: %s", err)
+				}
+
+				// Enable SO_REUSEPORT
+				err = syscall.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+				if err != nil {
+					log.Warningf("Could not set SO_REUSEPORT socket option: %s", err)
+				}
+			})
+		},
+	}
+
+	// Start Listener
+	l, err := lc.Listen(context.Background(), "tcp", addr)
+	return l, err
 }
 
 // GetPrometheusWriter returns an Prometheus DBWriter
@@ -204,8 +235,13 @@ func startPromSdListener(conf tomlConfig) error {
 	mux := http.NewServeMux()
 	mux.Handle("/", &h)
 	addr := fmt.Sprintf(":%d", conf.PromSD.SDport)
+	listener, err := createListener(addr)
+	if err != nil {
+		return fmt.Errorf("error creating listener for Prometheus HTTP SD: %w", err)
+	}
+	log.Infof("Starting Prometheus HTTP SD listener on %s", addr)
 	// XXX improve error handling here?
-	go func() { log.Error(http.ListenAndServe(addr, mux)) }()
+	go func() { log.Error(http.Serve(listener, mux)) }()
 	return nil
 }
 
@@ -235,12 +271,17 @@ func (p *PrometheusClient) Connect() error {
 		Handler: mux,
 	}
 
+	listener, err := createListener(addr)
+	if err != nil {
+		return fmt.Errorf("error creating listener for Prometheus client: %w", err)
+	}
+
 	go func() {
 		var err error
 		if p.TLSCert != "" && p.TLSKey != "" {
-			err = p.server.ListenAndServeTLS(p.TLSCert, p.TLSKey)
+			err = p.server.ServeTLS(listener, p.TLSCert, p.TLSKey)
 		} else {
-			err = p.server.ListenAndServe()
+			err = p.server.Serve(listener)
 		}
 		if err != nil && err != http.ErrServerClosed {
 			log.Errorf("error creating prometheus metric endpoint, err: %s\n",


### PR DESCRIPTION
The Golang net/http library functions such as http.ListenAndServe() do not seem to have any ability to set the reuseaddr and reuseport options. This is a problem because if the collector is stopped and then restarted within 2*MSL, then the bind operation will fail with address/port in use. This PR adds code that uses a net.ListenConfig{} to set these options.